### PR TITLE
docs: add warning for NuxtPage in app.vue (2.get-started.md)

### DIFF
--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -132,6 +132,10 @@ To render content pages, add a [catch-all route](https://nuxt.com/docs/guide/dir
 ```
 
 ::alert{type="warning"}
+⚠️ Your `app.vue` file must have a [`<NuxtPage />`](https://nuxt.com/docs/api/components/nuxt-page#nuxtpage) in its template to render correctly pages.
+::
+
+::alert{type="warning"}
 ⚠️ Content v2 requires [Nuxt 3](https://nuxt.com). If you are using Nuxt 2, checkout [Content v1 documentation](/v1/getting-started/installation).
 ::
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

None

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When I try Content for the first time, I already instantiate a nuxt app with the default template.

My `app.vue` was looking like that : 

```html
<template>
  <div>
    <NuxtWelcome />
  </div>
</template>
```

After executing what was written in the getting started, my nuxt app wasn't displaying my `content/index.md` page.
Instead, I was still seeing the `<NuxtWelcome />` component.

I'm not sure it's useful to create an issue for this, so I create a PR directly.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
